### PR TITLE
Fix issue #1 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-
-const RootLayout: React.FC = ({ children }) => {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  );
-};
-
-export default RootLayout;
+export default function RootLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <html lang="en">
+            <body>{children}</body>
+        </html>
+    );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,16 @@
-import 'bootstrap/dist/css/bootstrap.min.css';
-import '../css/global.css';
-import RootLayout from '../app/layout';
-import React from 'react';
+import "bootstrap/dist/css/bootstrap.min.css";
+import "../css/global.css";
+import React from "react";
 
 function MyApp({ Component, pageProps }) {
-  // Pass the component to the custom layout as a prop
-  const Layout = Component['Layout'] || React.Fragment;
+    // Pass the component to the custom layout as a prop
+    const Layout = Component["RootLayout"] || React.Fragment;
 
-  return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
-  );
+    return (
+        <Layout>
+            <Component {...pageProps} />
+        </Layout>
+    );
 }
 
 export default MyApp;


### PR DESCRIPTION
This pull request fixes issue #1 

pages/_app.tsx:
Use RootLayout, as it is the correct name of the layout component. This was the reason behind hydration error.

app/layout.tsx:
Additionally, type children prop correctly, as `Property 'children' does not exist on type '{}'.ts(2339)`